### PR TITLE
Keep HTML content secret to the impostor

### DIFF
--- a/api/post.py
+++ b/api/post.py
@@ -39,7 +39,7 @@ def fetch_html(context_, uuid):
 
     handle = context_.get('user', None)
 
-    return gfm_to_html(post.content), 200, { "Content-Type": "text/html" }
+    return post.get_api_representation(User.get_by_handle(handle, manager), true).content, 200, { "Content-Type": "text/html" }
 
 
 def create(context_, body: bytes):


### PR DESCRIPTION
This fix was achieved by using the functionality in `Post.get_api_representation` to provide HTML, as that function replaces the content AFTER parsing Markdown.

Fixes #2 